### PR TITLE
Add instant text option.

### DIFF
--- a/BPRE.ld
+++ b/BPRE.ld
@@ -1818,6 +1818,10 @@ GetEreaderTrainerFrontSpriteId = 0x80E7420 | 1;
 GetEreaderTrainerClassId = 0x80E7440 | 1;
 GetEreaderTrainerName = 0x80E7460 | 1;
 
+/* Instant Text */
+RenderFont = 0x8002E7C | 1;
+sTextPrinters = 0x2020034;
+GetTextSpeedSetting = 0x80f78a8 | 1;
 
 /* IO */
 BG3HOFS = 0x400001C;

--- a/asm_defines.s
+++ b/asm_defines.s
@@ -4081,3 +4081,7 @@
 .equ NATURE_SASSY, 22
 .equ NATURE_CAREFUL, 23
 .equ NATURE_QUIRKY, 24
+
+@ Instant text
+.equ sTempTextPrinter, 0x2020010
+.equ sTextPrinters, 0x2020034

--- a/assembly/hooks/instant_text_hooks.s
+++ b/assembly/hooks/instant_text_hooks.s
@@ -1,0 +1,38 @@
+
+	.thumb
+	.text
+	.align 2
+
+	.include "../asm_defines.s"
+
+@Hook at 0x8002d10 with r0
+FixInstantTextOptionSpeed:
+	cmp r5, #0x7f
+	bne FixInstantTextOptionSpeed_notInstantText
+	mov r5, #1
+FixInstantTextOptionSpeed_notInstantText:
+	ldr r0, =sTempTextPrinter
+	mov r1, #1
+	mov r2, #0
+	strb r1, [r0,#0x1b]
+	ldr r3, =0x8002d18 | 1
+	bx r3
+
+@Hook at 0x8002dee with r0
+RunTextPrintersForInstantTextHook:
+	bl RunTextPrintersForInstantText
+	cmp r0, #0
+	bne RunTextPrintersForInstantTextHook_wasInstantText
+	ldr r0, =sTextPrinters
+	mov r6, #0
+	add r5, r0, #4
+	mov r8, r0
+	mov r7, #0x1f
+	ldr r1, =0x8002df8 | 1
+	bx r1
+RunTextPrintersForInstantTextHook_wasInstantText:
+	ldr r1, =0x8002e5a | 1
+	bx r1
+
+gUnknown_841F428:
+	.byte 4, 1, 0x7f

--- a/hooks
+++ b/hooks
@@ -638,3 +638,8 @@ PlayerHandleBallThrowAnim 080327B0 0
 #endif
 
 ActivateMGBAPrint 81E381C 0
+
+#ifdef INSTANT_TEXT
+FixInstantTextOptionSpeed 08002D10 0
+RunTextPrintersForInstantTextHook 08002DEE 0
+#endif

--- a/include/new_menu_helpers.h
+++ b/include/new_menu_helpers.h
@@ -14,5 +14,6 @@ u8 __attribute((long_call)) GetPlayerTextSpeed(void);
 void __attribute__((long_call)) DrawDialogueFrameNewMenuHelpers(u8 windowId, bool8 transfer);
 u16 __attribute__((long_call)) AddTextPrinterParameterized2(u8 windowId, u8 fontId, const u8 *str, u8 speed, void (*callback)(struct TextPrinterTemplate *, u16), u8 fgColor, u8 bgColor, u8 shadowColor);
 void __attribute__((long_call)) DrawHelpMessageWindowWithText(const u8 * text);
+u8 __attribute__((long_call)) GetTextSpeedSetting(void);
 
 #endif // GUARD_NEW_MENU_HELPERS_H

--- a/include/text.h
+++ b/include/text.h
@@ -206,11 +206,7 @@ struct TextPrinter
 
     void (*callback)(struct TextPrinterTemplate *, u16); // 0x10
 
-    union
-#if !MODERN
-    __attribute__((packed))
-#endif
-    {
+    union __attribute__((packed)) {
         struct TextPrinterSubStruct sub;
         u8 fields[7];
     } subUnion;
@@ -297,7 +293,11 @@ void DeactivateAllTextPrinters(void);
 bool16 AddTextPrinter(struct TextSubPrinter *textSubPrinter, u8 speed, void (*callback)(struct TextSubPrinter *, u16));
 void RunTextPrinters(void);
 bool16 IsTextPrinterActive(u8 id);
-u32 RenderFont(struct TextPrinter *textPrinter);
+*/
+
+u32 __attribute__((long_call)) RenderFont(struct TextPrinter *textPrinter);
+
+/*
 void GenerateFontHalfRowLookupTable(u8 fgColor, u8 bgColor, u8 shadowColor);
 void SaveTextColors(u8 *fgColor, u8 *bgColor, u8 *shadowColor);
 void RestoreTextColors(u8 *fgColor, u8 *bgColor, u8 *shadowColor);

--- a/repoints
+++ b/repoints
@@ -263,3 +263,10 @@ DESC_NATURALGIFT 0887abfc
 DESC_QUASH 0887ac28
 DESC_ROCKCLIMB 0887ae64
 #endif
+
+#ifdef INSTANT_TEXT
+gUnknown_841F428 080f78dc
+gText_TextSpeedMid 083cc330
+gText_TextSpeedFast 083cc334
+gText_TextSpeedInstant 083cc338
+#endif

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -10,6 +10,9 @@ import subprocess
 import sys
 from string import StringFileConverter
 from make import ChangeFileLine
+import platform
+
+on_wsl = "microsoft" in platform.uname()[3].lower()
 
 if sys.platform.startswith('win'):
     PathVar = os.environ.get('Path')
@@ -42,9 +45,15 @@ else:  # Linux, OSX, etc.
     AS = PREFIX + 'as'
     CC = PREFIX + 'gcc'
     LD = PREFIX + 'ld'
-    GR = "grit"
-    WAV2AGB = 'wav2agb'
-    MID2AGB = 'mid2agb'
+    if on_wsl:
+        WAV2AGB = 'deps/wav2agb.exe'
+        MID2AGB = 'deps/mid2agb.exe'
+        GR = "deps/grit.exe"
+    else:
+        WAV2AGB = 'wav2agb'
+        MID2AGB = 'mid2agb'
+        GR = "grit"
+
     OBJCOPY = PREFIX + 'objcopy'
 
 SRC = './src'

--- a/src/config.h
+++ b/src/config.h
@@ -316,3 +316,5 @@ enum //These vars need to be one after the other (hence the enum)
 
 /* DexNav Options */
 //See "include/new/dexnav_config.h"
+
+//#define INSTANT_TEXT // Enable Instant Text. Some Hack Authors might want this disabled because of the effects instant text has on pacing

--- a/src/text_printer.c
+++ b/src/text_printer.c
@@ -1,0 +1,46 @@
+#include "../include/window.h"
+#include "../include/text.h"
+#include "../include/new_menu_helpers.h"
+
+extern struct TextPrinter sTextPrinters[];
+
+bool32 RunTextPrintersForInstantText(void) {
+    int i, j;
+    u16 result;
+
+    if (GetTextSpeedSetting() != 0x7f) {
+        return FALSE;
+    }
+
+    for (i = 0; i < 0x20; ++i)
+    {
+        if (sTextPrinters[i].active != 0)
+        {
+            for (j = 0; j < 0x400; j++) {
+                u32 oldState;
+                u32 newState;
+
+                oldState = sTextPrinters[i].state;
+                result = RenderFont(&sTextPrinters[i]);
+                newState = sTextPrinters[i].state;
+
+                if (result == 0) {
+                    if (sTextPrinters[i].callback != 0)
+                        sTextPrinters[i].callback(&sTextPrinters[i].printerTemplate, result);
+                } else if (result == 3) {
+                    if (sTextPrinters[i].callback != 0)
+                        sTextPrinters[i].callback(&sTextPrinters[i].printerTemplate, result);
+                    if (oldState == 0 && newState != 0)
+                        CopyWindowToVram(sTextPrinters[i].printerTemplate.windowId, 2);
+                    break;
+                } else if (result == 1) {
+                    CopyWindowToVram(sTextPrinters[i].printerTemplate.windowId, 2);
+                    sTextPrinters[i].active = 0;
+                    break;
+                }
+            }
+        }
+    }
+    
+    return TRUE;
+}

--- a/strings/instant_text.string
+++ b/strings/instant_text.string
@@ -1,0 +1,8 @@
+#org @gText_TextSpeedInstant
+INSTANT
+
+#org @gText_TextSpeedFast
+FAST
+
+#org @gText_TextSpeedMid
+MID


### PR DESCRIPTION
See https://github.com/luckytyphlosion/pokefirered/commit/0b124cb45f096fb2abe20c8de38652db8b1465db and https://github.com/luckytyphlosion/pokefirered/commit/a27b8f1458d92b96ace70bd0e80d4e85b29701e9 for the reference decomp implementations (tailored for binary insertion).