### PR TITLE
Correct special var names

### DIFF
--- a/include/constants/vars.h
+++ b/include/constants/vars.h
@@ -322,10 +322,10 @@
 #define VAR_RESULT                 0x800D
 #define VAR_ITEM_ID                0x800E
 #define VAR_LAST_TALKED            0x800F
-#define VAR_CONTEST_RANK           0x8010
-#define VAR_CONTEST_CATEGORY       0x8011
-#define VAR_MON_BOX_ID             0x8012
-#define VAR_MON_BOX_POS            0x8013
-#define VAR_TEXT_COLOR             0x8014
+#define VAR_MON_BOX_ID             0x8010
+#define VAR_MON_BOX_POS            0x8011
+#define VAR_TEXT_COLOR             0x8012
+#define VAR_PREV_TEXT_COLOR        0x8013
+#define VAR_0x8014                 0x8014 // Unknown/unused
 
 #define SPECIAL_VARS_END           0x8014


### PR DESCRIPTION
Some of the "Special Var" names appear to be incorrect/outdated (these were corrected on the decomp project at:
https://github.com/pret/pokefirered/commit/4ab3d77d8043fbf2dc7d7892b8e2f0ef1e96134f).

This was specifically to fix 0x8012 and 0x8013, which seems to be used to maintain a text color for system message boxes.