### PR TITLE
Fix for the error message in dynamax.c

### DIFF
--- a/src/dynamax.c
+++ b/src/dynamax.c
@@ -1923,9 +1923,9 @@ void sp11B_AllRaidBattlesCompleted(void)
 
 	for (u32 i = 0; i < KANTO_MAPSEC_COUNT; ++i)
 	{
-		if (gRaidsByMapSection[i] != NULL)
+		for (u32 j = 0; j < RAID_STAR_COUNT; ++j)
 		{
-			if (!FlagGet(FIRST_RAID_BATTLE_FLAG + i))
+			if (gRaidsByMapSection[i][j].data != NULL && !FlagGet(FIRST_RAID_BATTLE_FLAG + i))
 				return;
 		}
 	}


### PR DESCRIPTION
Fix the check in sp11B to include only the flags associated with map sections which has raids defined.