### PR TITLE
4 Pokedex Digits

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+    "files.associations": {
+        "party_menu.h": "c",
+        "types.h": "c",
+        "overworld.h": "c",
+        "text.h": "c"
+    }
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,6 +3,7 @@
         "party_menu.h": "c",
         "types.h": "c",
         "overworld.h": "c",
-        "text.h": "c"
+        "text.h": "c",
+        "config.h": "c"
     }
 }

--- a/BPRE.ld
+++ b/BPRE.ld
@@ -2022,6 +2022,9 @@ TitleScreen_CreateBlankSprite = 0x80799F0 | 1;
 /* Playtime Functions */
 PlayTimeCounter_SetToMax = 0x80548D4 | 1;
 
+/* Pokedex Functions */
+DexScreen_AddTextPrinterParameterized = 0x081047C8 | 1;
+
 /* Math Functions */
 Sine = 0x8044E30 | 1;
 Cosine = 0x8044E4C | 1;

--- a/bytereplacement
+++ b/bytereplacement
@@ -3,6 +3,7 @@
 #include "include/pokemon_storage_system.h"
 #include "include/constants/tutors.h"
 #include "include/new/catching.h"
+#include "include/pokedex.h"
 
 ##Optional Byte Changes##
 ##Don't Count Eggs Healing PKMN Centre
@@ -681,9 +682,11 @@
 #endif
 
 #ifdef NATIONAL_DEX_4_DIGITS
-08103A74 22 2D
-08103A94 22 7D
-08452186 3D
+08103A74 2C
+08103A94 7C
+08452186 3C
+08105F06 21
+08136126 04
 #endif
 
 #ifdef UNBOUND

--- a/bytereplacement
+++ b/bytereplacement
@@ -680,6 +680,12 @@
 083E05B0 88 E0 03 02 02 00 00 00 88 E0 03 02 03 00 00 00 88 E0 03 02 04 00 00 00 88 E0 03 02 05 00 00 00 88 E0 03 02 06 00 00 00 88 E0 03 02 07 00 00 00
 #endif
 
+#ifdef NATIONAL_DEX_4_DIGITS
+08103A74 22 2D
+08103A94 22 7D
+08452186 3D
+#endif
+
 #ifdef UNBOUND
 
 ##Specific For Unbound, overrites a hook that shouldn't be there with vanilla data.##

--- a/functionrewrites
+++ b/functionrewrites
@@ -1,4 +1,6 @@
 ##
+#include "include/pokedex.h"
+
 #ifdef NATIONAL_DEX_4_DIGITS
 DexScreen_PrintNumWLeadingZeroes 0x08104880 6 0
 #endif

--- a/functionrewrites
+++ b/functionrewrites
@@ -3,4 +3,5 @@
 
 #ifdef NATIONAL_DEX_4_DIGITS
 DexScreen_PrintNumWLeadingZeroes 0x08104880 6 0
+DexScreen_PrintNumWRightAlign 0x0810491C 6 0
 #endif

--- a/functionrewrites
+++ b/functionrewrites
@@ -1,1 +1,4 @@
 ##
+#ifdef NATIONAL_DEX_4_DIGITS
+DexScreen_PrintNumWLeadingZeroes 0x08104880 6 0
+#endif

--- a/include/pokedex.h
+++ b/include/pokedex.h
@@ -2,6 +2,10 @@
 
 #include "global.h"
 
+#if NATIONAL_DEX_COUNT > 999
+#define NATIONAL_DEX_4_DIGITS
+#endif
+
 enum
 {
     FLAG_GET_SEEN,
@@ -42,6 +46,7 @@ struct AlternateSize
 #define CAUGHT_DEX_FLAGS gSaveBlock1->dexCaughtFlags //0x20258B9
 
 bool16 __attribute__((long_call)) HasAllMons(void);
+void __attribute__((long_call)) DexScreen_AddTextPrinterParameterized(u8 windowId, u8 fontId, const u8 *str, u8 x, u8 y, u8 colorIdx);
 
 /*
 void ResetPokedex(void);

--- a/include/pokedex.h
+++ b/include/pokedex.h
@@ -47,6 +47,7 @@ struct AlternateSize
 
 bool16 __attribute__((long_call)) HasAllMons(void);
 void __attribute__((long_call)) DexScreen_AddTextPrinterParameterized(u8 windowId, u8 fontId, const u8 *str, u8 x, u8 y, u8 colorIdx);
+void __attribute__((long_call)) DexScreen_PrintNumWRightAlign(u8 windowId, u8 fontId, u16 num, u8 x, u8 y, u8 colorIdx)
 
 /*
 void ResetPokedex(void);

--- a/src/pokedex.c
+++ b/src/pokedex.c
@@ -1,0 +1,18 @@
+#include "../include/gba/types.h"
+#include "../include/text.h"
+
+void __attribute__((long_call)) DexScreen_AddTextPrinterParameterized(u8 windowId, u8 fontId, const u8 *str, u8 x, u8 y, u8 colorIdx);
+
+#if NATIONAL_DEX_COUNT < 999
+#define NATIONAL_DEX_4_DIGITS
+#endif
+
+void DexScreen_PrintNumWLeadingZeroes(u8 windowId, u8 fontId, u16 num, u8 x, u8 y, u8 colorIdx) {
+    u8 buff[5];
+    buff[0] = (num / 1000) + CHAR_0;
+    buff[1] = ((num %= 1000) / 100) + CHAR_0;
+    buff[2] = ((num %= 100) / 10) + CHAR_0;
+    buff[3] = (num % 10) + CHAR_0;
+    buff[4] = EOS;
+    DexScreen_AddTextPrinterParameterized(windowId, fontId, buff, x, y, colorIdx);
+}

--- a/src/pokedex.c
+++ b/src/pokedex.c
@@ -1,11 +1,6 @@
 #include "../include/gba/types.h"
 #include "../include/text.h"
-
-void __attribute__((long_call)) DexScreen_AddTextPrinterParameterized(u8 windowId, u8 fontId, const u8 *str, u8 x, u8 y, u8 colorIdx);
-
-#if NATIONAL_DEX_COUNT < 999
-#define NATIONAL_DEX_4_DIGITS
-#endif
+#include "../include/pokedex.h"
 
 void DexScreen_PrintNumWLeadingZeroes(u8 windowId, u8 fontId, u16 num, u8 x, u8 y, u8 colorIdx) {
     u8 buff[5];

--- a/src/pokedex.c
+++ b/src/pokedex.c
@@ -11,3 +11,21 @@ void DexScreen_PrintNumWLeadingZeroes(u8 windowId, u8 fontId, u16 num, u8 x, u8 
     buff[4] = EOS;
     DexScreen_AddTextPrinterParameterized(windowId, fontId, buff, x, y, colorIdx);
 }
+
+void DexScreen_PrintNumWRightAlign(u8 windowId, u8 fontId, u16 num, u8 x, u8 y, u8 colorIdx)
+{
+    u8 buff[5];
+    int i;
+    buff[0] = (num / 1000) + CHAR_0;
+    buff[1] = ((num %= 1000) / 100) + CHAR_0;
+    buff[2] = ((num %= 100) / 10) + CHAR_0;
+    buff[3] = (num % 10) + CHAR_0;
+    buff[4] = EOS;
+    for (i = 0; i < 4; i++)
+    {
+        if (buff[i] != CHAR_0)
+            break;
+        buff[i] = CHAR_SPACE;
+    }
+    DexScreen_AddTextPrinterParameterized(windowId, fontId, buff, x, y, colorIdx);
+}


### PR DESCRIPTION
In the vanilla Firered, the graphic support for dex numbers of Pokemon was 3 digits. I have extended it to 4.
Currently fixed pages:
* First page of Pokedex
* Second page of Pokedex
* Third page of Pokedex
* Info page of Pokemon

Here are some photos:
![image](https://github.com/user-attachments/assets/09024191-e033-4d2e-938d-4326c059a721)
![image](https://github.com/user-attachments/assets/2877c711-068d-4a75-ae90-8d7cf9ba6dc2)
![image](https://github.com/user-attachments/assets/01cd219b-36a4-42a4-92c0-e71d807b584e)
![image](https://github.com/user-attachments/assets/a57ddd3a-ea51-44e0-a311-a52d83a1de8b)


I would change if there are other pages that needs to extended to 4 digits.