### PR TITLE
Assembler fix

### DIFF
--- a/scripts/build.py
+++ b/scripts/build.py
@@ -64,7 +64,7 @@ STRINGS = './strings'
 AUDIO = './audio'
 BUILD = './build'
 IMAGES = './Images'
-ASFLAGS = ['-mthumb', '-I', ASSEMBLY]
+ASFLAGS = ['-mthumb', '-I', ASSEMBLY, '-mcpu=arm7tdmi', '-march=armv4t']
 LDFLAGS = ['BPRE.ld', '-T', 'linker.ld']
 CFLAGS = ['-mthumb', '-mno-thumb-interwork', '-mcpu=arm7tdmi', '-mtune=arm7tdmi',
           '-mno-long-calls', '-march=armv4t', '-Wall', '-Wextra', '-Os', '-fira-loop-pressure', '-fipa-pta']


### PR DESCRIPTION
**Issue:** [#130](https://github.com/Skeli789/Complete-Fire-Red-Upgrade/issues/130)
There were some flags missing in the assembler and the assembler tried to optimize some of the instructions with non-existent instructions in ARM7TDMI. Thus, caused illegal instructions.